### PR TITLE
fix: require authentication on all plugin views

### DIFF
--- a/proxmox2netbox/views/__init__.py
+++ b/proxmox2netbox/views/__init__.py
@@ -1,5 +1,6 @@
 import pathlib
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import render
 from django.views import View
 
@@ -51,7 +52,7 @@ __all__ = (
     "sync_virtual_machines",
 )
 
-class HomeView(View):
+class HomeView(LoginRequiredMixin, View):
     """
     ## HomeView class-based view to handle incoming GET HTTP requests.
     
@@ -88,7 +89,7 @@ class HomeView(View):
             }
         )
 
-class ContributingView(View):
+class ContributingView(LoginRequiredMixin, View):
     """
     **ContributingView** handles the rendering of the contributing page for the Proxmox2NetBox project.
     

--- a/proxmox2netbox/views/cards.py
+++ b/proxmox2netbox/views/cards.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
@@ -16,6 +17,7 @@ class HtmxHttpRequest(HttpRequest):
     htmx: HtmxDetails
 
 
+@login_required
 @require_GET
 def get_proxmox_card(
     request: HtmxHttpRequest,

--- a/proxmox2netbox/views/keepalive_status.py
+++ b/proxmox2netbox/views/keepalive_status.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
@@ -12,6 +13,7 @@ class HtmxHttpRequest(HttpRequest):
     htmx: HtmxDetails
 
 
+@login_required
 @require_GET
 def get_service_status(
     request: HtmxHttpRequest,

--- a/proxmox2netbox/views/sync.py
+++ b/proxmox2netbox/views/sync.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
@@ -38,6 +39,7 @@ def _run_sync(request: HtmxHttpRequest, template_name: str, sync_callable) -> Ht
     return render(request, template_name, {"result": result})
 
 
+@login_required
 @require_GET
 def sync_devices(request: HtmxHttpRequest) -> HttpResponse:
     return _run_sync(
@@ -47,6 +49,7 @@ def sync_devices(request: HtmxHttpRequest) -> HttpResponse:
     )
 
 
+@login_required
 @require_GET
 def sync_virtual_machines(request: HtmxHttpRequest) -> HttpResponse:
     return _run_sync(
@@ -56,6 +59,7 @@ def sync_virtual_machines(request: HtmxHttpRequest) -> HttpResponse:
     )
 
 
+@login_required
 @require_GET
 def sync_full_update(request: HtmxHttpRequest) -> HttpResponse:
     return _run_sync(


### PR DESCRIPTION
All custom views were accessible without authentication. Added @login_required to function-based views and LoginRequiredMixin to class-based views so unauthenticated users are redirected to the login page.