### PR TITLE
docs: refresh release and PyPI publishing guide

### DIFF
--- a/wiki/Release-and-PyPI.md
+++ b/wiki/Release-and-PyPI.md
@@ -1,34 +1,44 @@
-# Release and PyPI
+# Tags and Releases
 
-## Version bump
+Maintainer workflow for publishing `proxmox2netbox` to PyPI.
 
-Update both:
+## 1) Bump the version
 
-- `pyproject.toml` -> `[project].version`
-- plugin source config -> plugin `version`
+Before tagging a release, update version references to the same `X.Y.Z` value:
 
-## Trusted Publisher (OIDC)
+- `pyproject.toml` (`[project].version`)
+- `proxmox2netbox/__init__.py` (`Proxmox2NetBoxConfig.version`)
 
-Configure in PyPI for project `proxmox2netbox`:
+> Note: This repository currently does **not** contain `netbox_unifi_sync/version.py` or `netbox-plugin.yaml`.
+
+## 2) Configure PyPI Trusted Publisher (OIDC)
+
+In PyPI for project `proxmox2netbox`, configure a Trusted Publisher for this repository/workflow:
 
 - Owner: `patricklind`
 - Repository: `Proxmox2Netbox`
 - Workflow: `.github/workflows/publish-python-package.yml`
 - Environment: `pypi`
 
-## Release steps
+## 3) Create release tag `vX.Y.Z`
+
+Use one of these options:
+
+- **GitHub Actions: Create Release Tag** (manual dispatch, recommended), or
+- **Git manually**:
 
 ```bash
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-Workflow behavior:
+## 4) Workflow behavior
 
-- `release.yml` creates GitHub Release from tag.
-- `publish-python-package.yml` publishes package to PyPI.
+- `.github/workflows/release.yml` runs on tag push (`v*`), gates on lint/tests, then creates the GitHub Release.
+- `.github/workflows/publish-python-package.yml` runs on `release: published` and publishes to PyPI.
+- `publish-python-package.yml` also supports manual `workflow_dispatch` for retry.
 
-## Validate publish
+## 5) Validate publish
 
 ```bash
 pip install -U proxmox2netbox


### PR DESCRIPTION
### Motivation
- Clarify and consolidate the maintainer workflow for tagging and publishing `proxmox2netbox` to PyPI in a single, actionable guide. 
- Align version-bump instructions with files that actually exist in the repository and explicitly note missing references (`netbox_unifi_sync/version.py` and `netbox-plugin.yaml`).

### Description
- Rewrote `wiki/Release-and-PyPI.md` into `Tags and Releases` with step-by-step instructions for bumping versions, tagging, and publishing. 
- Specified which files to update before a release: `pyproject.toml` (`[project].version`) and `proxmox2netbox/__init__.py` (`Proxmox2NetBoxConfig.version`).
- Documented PyPI Trusted Publisher (OIDC) settings, the behavior of `.github/workflows/release.yml` and `.github/workflows/publish-python-package.yml`, and provided validation commands to confirm the published package.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a37bf1ec8328b6057b56a151d3d7)